### PR TITLE
Fixed axis inputs clashing with discrete inputs

### DIFF
--- a/Demo.tscn
+++ b/Demo.tscn
@@ -14,7 +14,7 @@
 [ext_resource path="res://interface/menus/pause/PauseMenu.tscn" type="PackedScene" id=12]
 [ext_resource path="res://interface/gui/lifebar/LifebarsBuilder.tscn" type="PackedScene" id=13]
 
-[node name="Game" type="Node"]
+[node name="Game" type="Node" index="0"]
 
 pause_mode = 1
 script = ExtResource( 1 )
@@ -129,10 +129,10 @@ _sections_unfolded = [ "Pause", "Theme" ]
 
 [node name="LifebarsBuilder" parent="Interface" index="3" instance=ExtResource( 13 )]
 
-[connection signal="loaded" from="LevelLoader" to="Interface" method="_on_Level_loaded"]
+[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
 
 [connection signal="loaded" from="LevelLoader" to="Overlays/ForegroundFog" method="_on_LevelLoader_loaded"]
 
-[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
+[connection signal="loaded" from="LevelLoader" to="Interface" method="_on_Level_loaded"]
 
 

--- a/Demo.tscn
+++ b/Demo.tscn
@@ -14,7 +14,7 @@
 [ext_resource path="res://interface/menus/pause/PauseMenu.tscn" type="PackedScene" id=12]
 [ext_resource path="res://interface/gui/lifebar/LifebarsBuilder.tscn" type="PackedScene" id=13]
 
-[node name="Game" type="Node" index="0"]
+[node name="Game" type="Node"]
 
 pause_mode = 1
 script = ExtResource( 1 )
@@ -129,10 +129,10 @@ _sections_unfolded = [ "Pause", "Theme" ]
 
 [node name="LifebarsBuilder" parent="Interface" index="3" instance=ExtResource( 13 )]
 
-[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
+[connection signal="loaded" from="LevelLoader" to="Interface" method="_on_Level_loaded"]
 
 [connection signal="loaded" from="LevelLoader" to="Overlays/ForegroundFog" method="_on_LevelLoader_loaded"]
 
-[connection signal="loaded" from="LevelLoader" to="Interface" method="_on_Level_loaded"]
+[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
 
 

--- a/Demo.tscn
+++ b/Demo.tscn
@@ -129,9 +129,9 @@ _sections_unfolded = [ "Pause", "Theme" ]
 
 [node name="LifebarsBuilder" parent="Interface" index="3" instance=ExtResource( 13 )]
 
-[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
-
 [connection signal="loaded" from="LevelLoader" to="Overlays/ForegroundFog" method="_on_LevelLoader_loaded"]
+
+[connection signal="loaded" from="LevelLoader" to="Background/BackgroundFog" method="_on_LevelLoader_loaded"]
 
 [connection signal="loaded" from="LevelLoader" to="Interface" method="_on_Level_loaded"]
 

--- a/actors/player/Player.tscn
+++ b/actors/player/Player.tscn
@@ -342,7 +342,7 @@ use_filter = true
 font_data = ExtResource( 17 )
 _sections_unfolded = [ "Font", "Settings" ]
 
-[node name="Player" type="KinematicBody2D"]
+[node name="Player" type="KinematicBody2D" index="0"]
 
 position = Vector2( 960, 550 )
 input_pickable = false
@@ -359,7 +359,6 @@ __meta__ = {
 
 [node name="HitBox" parent="." index="1" instance=ExtResource( 3 )]
 
-editor/display_folded = true
 monitorable = true
 
 [node name="CollisionShape2D" parent="HitBox" index="0"]
@@ -438,7 +437,6 @@ _sections_unfolded = [ "Transform", "Visibility" ]
 
 [node name="BodyPivot" type="Position2D" parent="." index="5"]
 
-editor/display_folded = true
 _sections_unfolded = [ "Material", "Transform", "Visibility" ]
 
 [node name="WeaponPivot" type="Position2D" parent="BodyPivot" index="0"]
@@ -502,8 +500,6 @@ MAXIMUM = 1000000
 
 [node name="Inventory" parent="." index="9" instance=ExtResource( 21 )]
 
-editor/display_folded = true
-
 [node name="MinorHealthPotion" parent="Inventory" index="0" instance=ExtResource( 22 )]
 
 amount = 4
@@ -512,7 +508,6 @@ amount = 4
 
 [node name="BulletSpawn" type="Node2D" parent="." index="10"]
 
-editor/display_folded = true
 position = Vector2( 1.17401, -61.266 )
 script = ExtResource( 24 )
 _sections_unfolded = [ "Transform" ]

--- a/actors/player/states/motion/Motion.gd
+++ b/actors/player/states/motion/Motion.gd
@@ -1,40 +1,17 @@
 # Collection of important methods to handle direction and animation
 extends "res://utils/state/State.gd"
 
-var joypad_dead_zone = ProjectSettings.get_setting("arpg/input/joypad_deadzone")
-
-enum PreferredInputSource { KEYBOARD, JOYPAD }
-var preferred_input_source = PreferredInputSource.KEYBOARD
-
 func handle_input(event):
-	if event is InputEventKey and preferred_input_source != PreferredInputSource.KEYBOARD:
-		preferred_input_source = PreferredInputSource.KEYBOARD
-		print("Key pressed. Changing preferred input method to keyboard...")
-	elif event is InputEventJoypadButton and preferred_input_source != PreferredInputSource.JOYPAD:
-		preferred_input_source = PreferredInputSource.JOYPAD
-		print("Joypad button pressed. Changing preferred input method to joypad...")
-	elif event is InputEventJoypadMotion and preferred_input_source != PreferredInputSource.JOYPAD:
-		if abs(event.axis_value) > joypad_dead_zone:
-			preferred_input_source = PreferredInputSource.JOYPAD
-			print("Gamepad axis exceeded deadzone. Changing preferred input method to joypad...")
-	
 	if event.is_action_pressed("simulate_damage"):
 		emit_signal("finished", "stagger")
 
 func get_input_direction():
 	var input_direction = Vector2()
 	
-	match preferred_input_source:
-		PreferredInputSource.KEYBOARD:
-			input_direction.x = int(Input.is_action_pressed("key_move_right")) - \
-				int(Input.is_action_pressed("key_move_left"))
-			input_direction.y = int(Input.is_action_pressed("key_move_down")) - \
-				int(Input.is_action_pressed("key_move_up"))
-		PreferredInputSource.JOYPAD:
-			input_direction.x = int(Input.is_action_pressed("joypad_move_right")) - \
-				int(Input.is_action_pressed("joypad_move_left"))
-			input_direction.y = int(Input.is_action_pressed("joypad_move_down")) - \
-				int(Input.is_action_pressed("joypad_move_up"))
+	input_direction.x = int(Input.is_action_pressed("key_move_right") or Input.is_action_pressed("joy_move_right")) - \
+		int(Input.is_action_pressed("key_move_left") or Input.is_action_pressed("joy_move_left"))
+	input_direction.y = int(Input.is_action_pressed("key_move_down") or Input.is_action_pressed("joy_move_down")) - \
+		int(Input.is_action_pressed("key_move_up") or Input.is_action_pressed("joy_move_up"))
 	
 	return input_direction
 

--- a/actors/player/states/motion/Motion.gd
+++ b/actors/player/states/motion/Motion.gd
@@ -1,14 +1,41 @@
 # Collection of important methods to handle direction and animation
 extends "res://utils/state/State.gd"
 
+var joypad_dead_zone = ProjectSettings.get_setting("arpg/input/joypad_deadzone")
+
+enum PreferredInputSource { KEYBOARD, JOYPAD }
+var preferred_input_source = PreferredInputSource.KEYBOARD
+
 func handle_input(event):
+	if event is InputEventKey and preferred_input_source != PreferredInputSource.KEYBOARD:
+		preferred_input_source = PreferredInputSource.KEYBOARD
+		print("Key pressed. Changing preferred input method to keyboard...")
+	elif event is InputEventJoypadButton and preferred_input_source != PreferredInputSource.JOYPAD:
+		preferred_input_source = PreferredInputSource.JOYPAD
+		print("Joypad button pressed. Changing preferred input method to joypad...")
+	elif event is InputEventJoypadMotion and preferred_input_source != PreferredInputSource.JOYPAD:
+		if abs(event.axis_value) > joypad_dead_zone:
+			preferred_input_source = PreferredInputSource.JOYPAD
+			print("Gamepad axis exceeded deadzone. Changing preferred input method to joypad...")
+	
 	if event.is_action_pressed("simulate_damage"):
 		emit_signal("finished", "stagger")
 
 func get_input_direction():
 	var input_direction = Vector2()
-	input_direction.x = int(Input.is_action_pressed("move_right")) - int(Input.is_action_pressed("move_left"))
-	input_direction.y = int(Input.is_action_pressed("move_down")) - int(Input.is_action_pressed("move_up"))
+	
+	match preferred_input_source:
+		PreferredInputSource.KEYBOARD:
+			input_direction.x = int(Input.is_action_pressed("key_move_right")) - \
+				int(Input.is_action_pressed("key_move_left"))
+			input_direction.y = int(Input.is_action_pressed("key_move_down")) - \
+				int(Input.is_action_pressed("key_move_up"))
+		PreferredInputSource.JOYPAD:
+			input_direction.x = int(Input.is_action_pressed("joypad_move_right")) - \
+				int(Input.is_action_pressed("joypad_move_left"))
+			input_direction.y = int(Input.is_action_pressed("joypad_move_down")) - \
+				int(Input.is_action_pressed("joypad_move_up"))
+	
 	return input_direction
 
 func update_look_direction(direction):

--- a/actors/player/states/motion/Motion.gd
+++ b/actors/player/states/motion/Motion.gd
@@ -8,10 +8,12 @@ func handle_input(event):
 func get_input_direction():
 	var input_direction = Vector2()
 	
-	input_direction.x = int(Input.is_action_pressed("key_move_right") or Input.is_action_pressed("joy_move_right")) - \
-		int(Input.is_action_pressed("key_move_left") or Input.is_action_pressed("joy_move_left"))
-	input_direction.y = int(Input.is_action_pressed("key_move_down") or Input.is_action_pressed("joy_move_down")) - \
-		int(Input.is_action_pressed("key_move_up") or Input.is_action_pressed("joy_move_up"))
+	input_direction.x = \
+		int(Input.is_action_pressed("discrete_move_right") or Input.is_action_pressed("joy_move_right")) - \
+		int(Input.is_action_pressed("discrete_move_left") or Input.is_action_pressed("joy_move_left"))
+	input_direction.y = \
+		int(Input.is_action_pressed("discrete_move_down") or Input.is_action_pressed("joy_move_down")) - \
+		int(Input.is_action_pressed("discrete_move_up") or Input.is_action_pressed("joy_move_up"))
 	
 	return input_direction
 

--- a/project.godot
+++ b/project.godot
@@ -22,10 +22,6 @@ run/main_scene="res://Demo.tscn"
 config/icon="res://icon.png"
 run/debug=true
 
-[arpg]
-
-input/joypad_deadzone=0.15
-
 [autoload]
 
 Steering="*res://utils/autoload/Steering.gd"
@@ -84,13 +80,13 @@ key_move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_n
 key_move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
  ]
-joypad_move_left=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
+joy_move_left=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
  ]
-joypad_move_right=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+joy_move_right=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
  ]
-joypad_move_up=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
+joy_move_up=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
  ]
-joypad_move_down=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
+joy_move_down=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 
 [layer_names]

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,10 @@ run/main_scene="res://Demo.tscn"
 config/icon="res://icon.png"
 run/debug=true
 
+[arpg]
+
+input/joypad_deadzone=0.15
+
 [autoload]
 
 Steering="*res://utils/autoload/Steering.gd"
@@ -40,19 +44,15 @@ window/stretch/aspect="keep"
 
 move_left=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
  ]
 move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
  ]
 move_right=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
  ]
 move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 fire=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
@@ -71,6 +71,26 @@ pause=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"",
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
  ]
 toggle_fullscreen=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"unicode":0,"echo":false,"script":null)
+ ]
+key_move_left=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
+ ]
+key_move_right=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
+ ]
+key_move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
+ ]
+key_move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
+ ]
+joypad_move_left=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
+ ]
+joypad_move_right=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+ ]
+joypad_move_up=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
+ ]
+joypad_move_down=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 
 [layer_names]

--- a/project.godot
+++ b/project.godot
@@ -56,16 +56,16 @@ pause=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"",
  ]
 toggle_fullscreen=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777254,"unicode":0,"echo":false,"script":null)
  ]
-key_move_left=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+discrete_move_left=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
  ]
-key_move_right=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+discrete_move_right=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
  ]
-key_move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+discrete_move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
  ]
-key_move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+discrete_move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
  ]
 joy_move_left=[ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)

--- a/project.godot
+++ b/project.godot
@@ -38,18 +38,6 @@ window/stretch/aspect="keep"
 
 [input]
 
-move_left=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
- ]
-move_up=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
- ]
-move_right=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
- ]
-move_down=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
- ]
 fire=[ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
  ]


### PR DESCRIPTION
I've noticed with some of my own projects that mixing axis inputs with other types of input in a single action (such as "move_left") can cause the two to "fight" each other. It mostly happens when you hold down a key for an action that also has an axis assigned to it. Randomly, you could just lose the state of the key being pressed until you lift the key and press it again. Other times, it can just ignore the keypress altogether. I think it's a timing-specific thing with the engine's input code if the analog sensor in the gamepad momentarily exceeds its deadzone (which can happen, especially with noisier sensors).

I saw this behavior occurring right away when I first ran this project and implemented a simplified version of the fix I did in one of my own projects to get around this issue. Basically, actions with axis inputs are split into two actions. I named these "discrete_move_left", "joy_move_left", etc. I called the keyboard version "discrete" rather than "key" as a pattern. The only thing needed to fix this issue is to keep axes separate from discrete inputs. You could add D-Pad buttons to the discrete actions alongside the keyboard without any issues. I didn't do so here only because I didn't know if we had something in mind for the D-Pad in the future.

Just to reiterate, not all actions will need duplicate actions for joypad. Only actions with axis inputs seem to cause problems. This may not have been an issue for most people, but if I'm encountering this across multiple projects and versions of Godot, then it might also affect others in the future.

- [X] __Motion.gd__: Fixed random axis input collisions on "move_xxx" actions with discrete input
- [X] __godot.project__: Split the following actions into two actions:
  - "move_left" => "discrete_move_left", "joy_move_left"
  - "move_right" => "discrete_move_right", "joy_move_right"
  - "move_up" => "discrete_move_up", "joy_move_up"
  - "move_down" => "discrete_move_down", "joy_move_down"