### PR TITLE
Fixed player hanging in air when falling in holes

### DIFF
--- a/Demo.tscn
+++ b/Demo.tscn
@@ -14,7 +14,7 @@
 [ext_resource path="res://interface/menus/pause/PauseMenu.tscn" type="PackedScene" id=12]
 [ext_resource path="res://interface/gui/lifebar/LifebarsBuilder.tscn" type="PackedScene" id=13]
 
-[node name="Game" type="Node" index="0"]
+[node name="Game" type="Node"]
 
 pause_mode = 1
 script = ExtResource( 1 )

--- a/actors/player/PlayerStateMachine.gd
+++ b/actors/player/PlayerStateMachine.gd
@@ -18,6 +18,10 @@ func _change_state(state_name):
 	if current_state == states_map['die']:
 		set_active(false)
 		return
+	# Reset the player's jump height if transitioning away from jump to a state
+	# that would stop jump's update method
+	if current_state == states_map['jump'] and state_name in ['fall']:
+		current_state.height = 0
 	if not active:
 		return
 	if state_name in ['stagger', 'jump', 'attack']:

--- a/actors/player/states/motion/in_air/Jump.gd
+++ b/actors/player/states/motion/in_air/Jump.gd
@@ -18,7 +18,7 @@ var horizontal_speed = 0.0
 var horizontal_velocity = Vector2()
 
 var vertical_speed = 0.0
-var height = 0.0
+var height = 0.0 setget set_height
 
 func initialize(speed, velocity):
 	horizontal_speed = speed
@@ -40,6 +40,7 @@ func update(delta):
 
 	move_horizontally(delta, input_direction)
 	animate_jump_height(delta)
+
 	if height <= 0.0:
 		emit_signal("finished", "previous")
 
@@ -57,9 +58,10 @@ func move_horizontally(delta, direction):
 	owner.move_and_slide(horizontal_velocity)
 	owner.emit_signal("position_changed", owner.position)
 
+func set_height(new_height):
+	height = new_height
+	owner.get_node("BodyPivot").position.y = -height
+
 func animate_jump_height(delta):
 	vertical_speed -= GRAVITY * delta
-	height += vertical_speed * delta
-	height = max(0.0, height)
-
-	owner.get_node("BodyPivot").position.y = -height
+	set_height(max(0.0, height + vertical_speed * delta))


### PR DESCRIPTION
I noticed that the player's height does not return back to 0 if they drop into a hole mid-jump. Thus, the player ends up inadvertently gaining the ability to fly until pressing the jump button again. This PR simply adds a check to _PlayerStateMachine.gd_ to determine whether the player is switching to a state that would prevent the jump state's update method from completing the jump. If so, then the jump state's height is set to 0 with a newly added setter method in _Jump.gd_

I'm not sure if we intend to have the player able to jump over those holes in the future, but I think until that decision is made, this fixes an easily reproducible bug.

- [X] __Jump.gd__: Added set_height as setter for the height field
- [X] __Jump.gd__: Slightly refactored animate_jump_height to call set_height
- [X] __PlayerStateMachine.gd__: Added check for a state transition to a state that would interrupt Jump from bringing the player's height back to 0, in which case the height is now set to 0