### PR TITLE
Fix game crashing when player dies. Instead, game restarts.

### DIFF
--- a/actors/player/PlayerController.gd
+++ b/actors/player/PlayerController.gd
@@ -45,6 +45,8 @@ func fall(gap_size):
 
 func _on_Die_finished(string):
 	set_dead(true)
+	get_tree().change_scene("res://Demo.tscn")
+	
 
 func get_health_node():
 	return $Health

--- a/actors/player/PlayerStateMachine.gd
+++ b/actors/player/PlayerStateMachine.gd
@@ -37,7 +37,8 @@ func _unhandled_input(event):
 		_change_state('attack')
 		get_tree().set_input_as_handled()
 		return
-	current_state.handle_input(event)
+	if current_state:
+		current_state.handle_input(event)
 
 func _on_Health_damage_taken(new_health):
 	_change_state('stagger')

--- a/utils/state/StateMachine.gd
+++ b/utils/state/StateMachine.gd
@@ -33,7 +33,8 @@ func set_active(value):
 		current_state = null
 
 func _unhandled_input(event):
-	current_state.handle_input(event)
+	if current_state:
+		current_state.handle_input(event)
 
 func _physics_process(delta):
 	current_state.update(delta)


### PR DESCRIPTION
Fixes https://github.com/GDquest/make-pro-2d-games-with-godot/issues/93

Let me know if you'd like this handled in a different way.

I did the simplest way possible, but I could also add a "Game Over" screen if you could specify exactly how it should look like.